### PR TITLE
Fix/pin memory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "octorun"
-version = "0.2.0"
+version = "0.2.1"
 description = "A command-line tool for distributed parallel execution across multiple GPUs"
 readme = "README.md"
 authors = [

--- a/src/octorun/__init__.py
+++ b/src/octorun/__init__.py
@@ -1,3 +1,3 @@
 """OctoRun - A command-line tool for running tasks and scripts."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/src/octorun/benchmarks/memory_benchmark.py
+++ b/src/octorun/benchmarks/memory_benchmark.py
@@ -40,7 +40,7 @@ def test_memory_bandwidth_torch(gpu_id, duration=5.0):
     while (time.time() - start_time) < duration:
         torch.cuda.synchronize()
         # Copy operation
-        data_copy = data.to(device=device)
+        data_copy = data.to(device=device, non_blocking=True)
         torch.cuda.synchronize()
         operations += 1
     

--- a/src/octorun/benchmarks/memory_benchmark.py
+++ b/src/octorun/benchmarks/memory_benchmark.py
@@ -31,7 +31,7 @@ def test_memory_bandwidth_torch(gpu_id, duration=5.0):
     dtype = torch.float32 # cpu does not support bf16
     
     # Memory copy test
-    data = torch.randn(size, device='cpu', dtype=dtype)
+    data = torch.randn(size, device='cpu', dtype=dtype, pin_memory=True)
     bytes_per_element = data.element_size()
     
     operations = 0

--- a/uv.lock
+++ b/uv.lock
@@ -314,7 +314,7 @@ wheels = [
 
 [[package]]
 name = "octorun"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "torch" },


### PR DESCRIPTION
This pull request updates the version of the `octorun` package and introduces performance improvements to the GPU memory bandwidth benchmark. The main changes focus on optimizing memory copy operations in the benchmarking code to better utilize pinned memory and non-blocking transfers.

Version bump:

* Updated the package version from `0.2.0` to `0.2.1` in both `pyproject.toml` and `src/octorun/__init__.py` to reflect the new release. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-554b887eb7422d5243fa926353a8c5a6e4853bfbf1c41922ff06d55ecd2312a3L3-R3)

Benchmark performance improvements:

* In `src/octorun/benchmarks/memory_benchmark.py`, enabled pinned memory for the source tensor in the memory copy test by setting `pin_memory=True` in `torch.randn`. This allows for faster data transfers between CPU and GPU.
* Changed the `.to()` operation to use `non_blocking=True`, enabling asynchronous data transfers to the GPU for improved performance during benchmarking.