### PR TITLE
feat: configurable success_codes and append-mode chunk logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,21 @@ Generate a starter config with `octorun save_config`, then edit as needed:
 | `monitor_interval` | Seconds between process-status checks | `60` |
 | `restart_failed` | Retry failed chunks | `false` |
 | `max_retries` | Maximum retries per chunk | `3` |
+| `success_codes` | Worker exit codes treated as success | `[0]` |
 | `kwargs` | Extra arguments forwarded to your script | `{}` |
+
+### `success_codes`
+
+By default a chunk is considered complete only when the worker exits with code `0`.
+Add additional codes here when your worker has a known-benign non-zero exit. For
+example, if the worker calls `sys.exit(0)` but the CPython interpreter shutdown
+phase fails (often `120` due to atexit / stdout-flush errors on slow networked
+filesystems), the chunk's data is already written and you can safely treat `120`
+as success:
+
+```json
+"success_codes": [0, 120]
+```
 
 ## Writing a Worker Script
 
@@ -274,6 +288,19 @@ Monitor all machines from anywhere:
 ```bash
 octorun status ./logs
 ```
+
+### Shared filesystem requirements
+
+`chunk_lock_dir` relies on `O_CREAT | O_EXCL` having atomic, cross-client
+semantics. **Use a POSIX-compliant filesystem** (local disk, NFS, CephFS, etc.).
+
+**Do not place `chunk_lock_dir` on object-storage-backed filesystems** such as
+HDFS-fuse or s3fs — they typically fall back to non-atomic
+"stat-then-create" sequences and have client-side metadata caching, both of
+which let two workers acquire the same lock. Output data can still live on
+HDFS / S3, but locking requires a real filesystem. If you must run on such
+storage, ensure your worker writes outputs idempotently (`tmp + rename`) and
+treat the lock as best-effort rather than a correctness guarantee.
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "octorun"
-version = "1.0.0"
+version = "1.0.1"
 description = "A command-line tool for distributed parallel execution across multiple GPUs"
 readme = "README.md"
 authors = [

--- a/src/octorun/__init__.py
+++ b/src/octorun/__init__.py
@@ -1,3 +1,3 @@
 """OctoRun - A command-line tool for running tasks and scripts."""
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/src/octorun/default_config.json
+++ b/src/octorun/default_config.json
@@ -11,5 +11,6 @@
     "monitor_interval": 60,
     "restart_failed": false,
     "max_retries": 3,
-    "memory_threshold": 90
+    "memory_threshold": 90,
+    "success_codes": [0]
 }

--- a/src/octorun/runner.py
+++ b/src/octorun/runner.py
@@ -114,11 +114,15 @@ class ProcessManager:
             # Setup environment
             env = os.environ.copy()
 
-            # Setup logging
+            # Setup logging — append, not truncate. Preserves prior attempts'
+            # output across retries, and avoids a 30s lease-conflict stall on
+            # networked filesystems (HDFS-fuse) where O_TRUNC blocks while
+            # another writer holds the file.
             log_file = os.path.join(self.config['log_dir'], f"chunk_{chunk_id}.log")
 
-            with open(log_file, 'w') as f:
-                f.write(f"Starting process on GPU {gpu_id}, chunk {chunk_id}\n")
+            with open(log_file, 'a') as f:
+                f.write(f"=== Starting process on GPU {gpu_id}, chunk {chunk_id} "
+                        f"({datetime.datetime.now().isoformat()}) ===\n")
                 f.write(f"Command: {' '.join(cmd)}\n")
                 f.write("-" * 50 + "\n")
 
@@ -162,7 +166,8 @@ class ProcessManager:
             else:
                 # Process finished
                 return_code = process.returncode
-                if return_code == 0:
+                success_codes = self.config.get('success_codes', [0])
+                if return_code in success_codes:
                     status['completed'].append(chunk_id)
                     self.completed_chunks.add(chunk_id)
                     proc_info['status'] = 'completed'


### PR DESCRIPTION
Two robustness improvements that are useful generally and especially on slow networked filesystems:

1. success_codes config — exit codes treated as success are now configurable (default [0]). Lets users opt in to accepting known-benign non-zero exits such as 120 (CPython interpreter-shutdown failures, common on HDFS-fuse when stdout-flush trips at process exit) without baking that policy into octorun.

2. chunk_<id>.log opened in append mode — preserves prior attempts' stdout across retries (useful for debugging) and avoids a 30s O_TRUNC lease- conflict stall on networked filesystems where another writer still holds the file.

Also documents the chunk_lock_dir filesystem requirement (POSIX O_EXCL must be atomic across clients) and warns against placing locks on HDFS-fuse / s3fs.